### PR TITLE
(#2) Better ARM support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.3
+
+**Features**
+
+* [#2](https://github.com/danielparks/puppet-golang/issues/2): support
+  convenient installation on Raspberry Pi 2B and 3B.
+
+**Bugfixes**
+
+* [#2](https://github.com/danielparks/puppet-golang/issues/2): default to the
+  correct 64-bit ARM binary on 64 bit ARM, e.g. on the Raspberry Pi 4.
+
 ## Release 1.0.2
 
 **Features**

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,9 +28,10 @@ class golang (
   },
   String[1]        $arch          = $facts['os']['hardware'] ? {
     undef     => 'amd64', # Assume amd64 if os.hardware is missing.
-    'x86_64'  => 'amd64',
+    'aarch64' => 'arm64',
+    'armv7l'  => 'armv6l',
     'i686'    => '386',
-    'aarch64' => 'armv6l',
+    'x86_64'  => 'amd64',
     default   => $facts['os']['hardware'],
   },
   String[1]        $source        = "${source_prefix}/go${version}.${os}-${arch}.tar.gz",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "dp-golang",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Daniel Parks",
   "summary": "Install Go simply",
   "license": "Apache-2.0",


### PR DESCRIPTION
  * In 1.0.2 I incorrectly set the default for 64-bit ARM to use the 32-bit armv6l binaries. This corrects it to use the arm64 binaries.
  * This changes the default on 32 bit ARM platforms to download the armv6l binaries. This makes installation on the Raspberry PIs prior to the 4 more convenient.