### PR TITLE
(#14) Add basic acceptance tests with Puppet Litmus

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,3 +4,8 @@
 fixtures:
   forge_modules:
     archive: "puppet/archive"
+  # https://puppetlabs.github.io/litmus/Converting-modules-to-use-Litmus.html
+  repositories:
+    facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
+    provision: 'https://github.com/puppetlabs/provision.git'

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -33,3 +33,18 @@ jobs:
         bundler-cache: true
     - run: gem install --no-document --minimal-deps pdk
     - run: pdk test unit
+
+  test-acceptance:
+    name: Acceptance tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "2.7"
+        bundler-cache: true
+    - run: bundle exec rake 'litmus:provision[docker, litmusimage/centos:7]'
+    - run: bundle exec rake 'litmus:install_agent[puppet7]'
+    - run: bundle exec rake 'litmus:install_module'
+    - run: bundle exec rake 'litmus:acceptance:parallel'

--- a/.sync.yml
+++ b/.sync.yml
@@ -14,6 +14,8 @@ common:
   paths:
     - /.github
     - /provision.yaml
+    - /test.sh
+    - /util.sh
 
 .editorconfig:
   unmanaged: true
@@ -25,6 +27,13 @@ appveyor.yml:
   delete: true
 .travis.yml:
   delete: true
+
+Gemfile:
+  optional:
+    ':development':
+      - gem: 'puppet_litmus'
+        git: 'https://github.com/puppetlabs/puppet_litmus'
+        ref: 'main'
 
 .rubocop.yml:
   default_configs:

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development do
   gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "voxpupuli-puppet-lint-plugins", '>= 3.0',                 require: false
+  gem "puppet_litmus",                                           require: false, git: 'https://github.com/puppetlabs/puppet_litmus', ref: 'main'
   gem "puppet-lint-legacy_facts-check",                          require: false
 end
 group :system_tests do

--- a/provision.yaml
+++ b/provision.yaml
@@ -1,0 +1,4 @@
+---
+default:
+  provisioner: vagrant
+  images: ['centos/7']

--- a/spec/acceptance/golang_spec.rb
+++ b/spec/acceptance/golang_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'Install Go' do
+  context 'without parameters' do
+    it { idempotent_apply('include golang') }
+
+    describe file('/usr/local/go') do
+      it { is_expected.to be_directory }
+      it { is_expected.to be_owned_by 'root' }
+    end
+
+    describe file('/usr/local/go/bin/go') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_executable }
+      it { is_expected.to be_owned_by 'root' }
+    end
+
+    describe file('/usr/local/bin/go') do
+      it { is_expected.to be_symlink }
+      it { is_expected.to be_linked_to '/usr/local/go/bin/go' }
+    end
+
+    describe command('/usr/local/bin/go version') do
+      its(:stdout) { is_expected.to match(%r{\Ago version }) }
+      its(:stderr) { is_expected.to eq '' }
+      its(:exit_status) { is_expected.to eq 0 }
+    end
+  end
+
+  context 'with a specific version' do
+    it do
+      idempotent_apply(<<~'END')
+        class { 'golang':
+          version => '1.10.4',
+        }
+      END
+    end
+
+    describe file('/usr/local/go') do
+      it { is_expected.to be_directory }
+      it { is_expected.to be_owned_by 'root' }
+    end
+
+    describe file('/usr/local/go/bin/go') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_executable }
+      it { is_expected.to be_owned_by 'root' }
+    end
+
+    describe file('/usr/local/bin/go') do
+      it { is_expected.to be_symlink }
+      it { is_expected.to be_linked_to '/usr/local/go/bin/go' }
+    end
+
+    describe command('/usr/local/bin/go version') do
+      its(:stdout) { is_expected.to match(%r{\Ago version go1.10.4 }) }
+      its(:stderr) { is_expected.to eq '' }
+      its(:exit_status) { is_expected.to eq 0 }
+    end
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Created to use litmus per:
+# https://puppetlabs.github.io/litmus/Converting-modules-to-use-Litmus.html
+
+require 'puppet_litmus'
+PuppetLitmus.configure!
+
+require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -e
+
+export UTIL_TRACE=1
+source util.sh
+
+usage () {
+  echo "Usage: $0 COMMAND [COMMAND...]"
+  echo ""
+  echo "COMMAND may be one of:"
+  echo "  init       initialize test set up"
+  echo "  snapshot   save a snapshot called 'general'"
+  echo "  restore    restore a snapshot called 'general'"
+  echo "  fast-init  restore to post-init state and reinstall the module"
+  echo "  update     reinstall module"
+  echo "  run        run tests"
+  echo "  destroy    destroy virtual machines"
+}
+
+init () {
+  # FIXME sometimes we just want to ensure that things are set up, and not
+  # actually recreate everything
+  destroy
+  rake 'litmus:provision_list[default]'
+
+  bolt_task_run puppet_agent::install collection=puppet6 version=latest
+  bolt_task_run provision::fix_secure_path path=/opt/puppetlabs/bin
+  snapshot fresh
+  rake litmus:install_module
+}
+
+snapshot () {
+  local name=${1:-general}
+  for box in .vagrant/*/Vagrantfile ; do
+    (
+      cd "$(dirname "$box")"
+      vagrant snapshot save "$name"
+    )
+  done
+}
+
+restore () {
+  local name=${1:-general}
+  for box in .vagrant/*/Vagrantfile ; do
+    (
+      cd "$(dirname "$box")"
+      vagrant snapshot restore "$name"
+    )
+  done
+}
+
+fast-init () {
+  restore fresh
+  rake litmus:install_module
+}
+
+update () {
+  rake litmus:reinstall_module
+}
+
+run () {
+  rake litmus:acceptance:parallel
+}
+
+destroy () {
+  if [ -f spec/fixtures/litmus_inventory.yaml ] ; then
+    # If there’s no inventory, there’s nothing to tear down.
+    rake litmus:tear_down
+  fi
+}
+
+if [[ -z "$*" ]] ; then
+  usage >&2
+  exit 1
+fi
+
+for action in "$@" ; do
+  case "$action" in
+    init|snapshot|restore|fast-init|update|run|destroy) "$action" ;;
+    --help) usage ;;
+    *) usage >&2 ; exit 1 ;;
+  esac
+done

--- a/util.sh
+++ b/util.sh
@@ -1,0 +1,21 @@
+# Source this file to get convenient rake and bolt_task_run functions.
+#
+# Set UTIL_TRACE to print the function and its parameters before running.
+
+util_trace () {
+  [[ -z "$UTIL_TRACE" ]] || echo "$*"
+}
+
+rake () {
+  util_trace "rake $*"
+  pdk bundle exec rake "$@"
+}
+
+bolt_task_run () {
+  util_trace "bolt_task_run $*"
+  BOLT_GEM=1 pdk bundle exec bolt task run \
+    --modulepath spec/fixtures/modules \
+    --inventoryfile spec/fixtures/litmus_inventory.yaml \
+    --targets '*' \
+    "$@"
+}


### PR DESCRIPTION
This adds basic acceptance tests to confirm that code works in the simplest cases.

For some reason the Puppet agent installation is broken on Ubuntu Trusty, so this only provisions on CentOS by default.

This also adds a GitHub action job to check acceptance tests. It checks on Ubuntu.