### PR TITLE
(#16) Enable uninstalling Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+**Features**
+
+* Added `ensure` parameter to allow uninstalling Go.
+
 **Bugfixes**
 
 * Used pre-release version of Puppet Strings to (mostly) fix parameter default

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ class { 'golang':
 }
 ```
 
+To uninstall Go, just do:
+
+``` puppet
+class { 'golang':
+  ensure => absent,
+}
+```
+
 ## Limitations
 
 This does not support Windows.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -20,12 +20,22 @@ Most people will not need to change any parameter other than `$version`.
 
 The following parameters are available in the `golang` class:
 
+* [`ensure`](#-golang--ensure)
 * [`version`](#-golang--version)
 * [`link_binaries`](#-golang--link_binaries)
 * [`source_prefix`](#-golang--source_prefix)
 * [`os`](#-golang--os)
 * [`arch`](#-golang--arch)
 * [`source`](#-golang--source)
+
+##### <a name="-golang--ensure"></a>`ensure`
+
+Data type: `Enum[present, absent]`
+
+* `present`: Make sure go is installed.
+* `absent`: Make sure go is uninstalled.
+
+Default value: `present`
 
 ##### <a name="-golang--version"></a>`version`
 

--- a/spec/acceptance/golang_spec.rb
+++ b/spec/acceptance/golang_spec.rb
@@ -2,34 +2,8 @@
 
 require 'spec_helper_acceptance'
 
-describe 'Install Go' do
-  context 'without parameters' do
-    it { idempotent_apply('include golang') }
-
-    describe file('/usr/local/go') do
-      it { is_expected.to be_directory }
-      it { is_expected.to be_owned_by 'root' }
-    end
-
-    describe file('/usr/local/go/bin/go') do
-      it { is_expected.to be_file }
-      it { is_expected.to be_executable }
-      it { is_expected.to be_owned_by 'root' }
-    end
-
-    describe file('/usr/local/bin/go') do
-      it { is_expected.to be_symlink }
-      it { is_expected.to be_linked_to '/usr/local/go/bin/go' }
-    end
-
-    describe command('/usr/local/bin/go version') do
-      its(:stdout) { is_expected.to match(%r{\Ago version }) }
-      its(:stderr) { is_expected.to eq '' }
-      its(:exit_status) { is_expected.to eq 0 }
-    end
-  end
-
-  context 'with a specific version' do
+describe 'golang' do
+  context 'install with a specific version' do
     it do
       idempotent_apply(<<~'END')
         class { 'golang':
@@ -58,6 +32,55 @@ describe 'Install Go' do
       its(:stdout) { is_expected.to match(%r{\Ago version go1.10.4 }) }
       its(:stderr) { is_expected.to eq '' }
       its(:exit_status) { is_expected.to eq 0 }
+    end
+  end
+
+  context 'install without parameters' do
+    it { idempotent_apply('include golang') }
+
+    describe file('/usr/local/go') do
+      it { is_expected.to be_directory }
+      it { is_expected.to be_owned_by 'root' }
+    end
+
+    describe file('/usr/local/go/bin/go') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_executable }
+      it { is_expected.to be_owned_by 'root' }
+    end
+
+    describe file('/usr/local/bin/go') do
+      it { is_expected.to be_symlink }
+      it { is_expected.to be_linked_to '/usr/local/go/bin/go' }
+    end
+
+    describe command('/usr/local/bin/go version') do
+      its(:stdout) { is_expected.to match(%r{\Ago version }) }
+      its(:stderr) { is_expected.to eq '' }
+      its(:exit_status) { is_expected.to eq 0 }
+    end
+  end
+
+  describe 'uninstall' do
+    it do
+      # These tests are run in order, so this isn’t strictly necessary. However,
+      # I’d prefer to avoid relying on the previous tests, so here it is. In
+      # order to avoid unnecessary changes, this should match the last test run
+      apply_manifest('include golang')
+
+      idempotent_apply(<<~'END')
+        class { 'golang':
+          ensure => absent,
+        }
+      END
+    end
+
+    describe file('/usr/local/go') do
+      it { is_expected.not_to exist }
+    end
+
+    describe file('/usr/local/bin/go') do
+      it { is_expected.not_to exist }
     end
   end
 end

--- a/spec/classes/golang_spec.rb
+++ b/spec/classes/golang_spec.rb
@@ -7,7 +7,17 @@ describe 'golang' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to compile }
+      describe 'default' do
+        it { is_expected.to compile }
+      end
+
+      describe 'ensure => absent' do
+        let(:params) do
+          { ensure: 'absent' }
+        end
+
+        it { is_expected.to compile }
+      end
     end
   end
 end


### PR DESCRIPTION
Adds `$ensure` parameter that may be set to `absent` to remove the Go installation.