### PR TITLE
Match minimum Puppet version to puppet/archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## main branch
+
+### Bug fixes
+
+* Updated minimum Puppet version to match puppet/archive. [archive version
+  4.0.0][https://forge.puppet.com/modules/puppet/archive/4.0.0] requires Puppet
+  5.5.8 or higher, so this module must as well.
+
 ## Release 1.1.0
 
 ### Features

--- a/metadata.json
+++ b/metadata.json
@@ -73,7 +73,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0"
+      "version_requirement": ">= 5.5.8"
     }
   ],
   "pdk-version": "2.5.0",


### PR DESCRIPTION
puppet/archive 4.0.0 required Puppet 5.5.8 or higher.