### PR TITLE
Use `Stdlib::HTTPUrl`

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,7 @@
 fixtures:
   forge_modules:
     archive: "puppet/archive"
+    stdlib: "puppetlabs/stdlib"
   # https://puppetlabs.github.io/litmus/Converting-modules-to-use-Litmus.html
   repositories:
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+### Improvements
+
+* Use [`Stdlib::HTTPUrl`][] data type for URL parameters.
+
+[`Stdlib::HTTPUrl`]: https://github.com/puppetlabs/puppetlabs-stdlib/blob/0f032a9bc557949169f565bf41e5aa1f35b17346/REFERENCE.md#stdlibhttpurl
+
 ### Bug fixes
 
 * Updated minimum Puppet version to match puppet/archive. [archive version

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -56,7 +56,7 @@ Default value: `['go', 'gofmt']`
 
 ##### <a name="-golang--source_prefix"></a>`source_prefix`
 
-Data type: `String[1]`
+Data type: `Stdlib::HTTPUrl`
 
 URL to directory that contains the archive to download.
 
@@ -97,7 +97,7 @@ $facts['os']['hardware'] ? {
 
 ##### <a name="-golang--source"></a>`source`
 
-Data type: `String[1]`
+Data type: `Stdlib::HTTPUrl`
 
 URL to actual archive.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,7 @@ class golang (
   Enum[present, absent] $ensure        = present,
   String[1]             $version       = '1.19.1',
   Array[String[1]]      $link_binaries = ['go', 'gofmt'],
-  String[1]             $source_prefix = 'https://go.dev/dl',
+  Stdlib::HTTPUrl       $source_prefix = 'https://go.dev/dl',
   String[1]             $os            = $facts['kernel'] ? {
     'Linux'  => 'linux',
     'Darwin' => 'darwin',
@@ -38,7 +38,7 @@ class golang (
     'x86_64'  => 'amd64',
     default   => $facts['os']['hardware'], # lint:ignore:parameter_documentation broken
   },
-  String[1]             $source        = "${source_prefix}/go${version}.${os}-${arch}.tar.gz",
+  Stdlib::HTTPUrl       $source        = "${source_prefix}/go${version}.${os}-${arch}.tar.gz",
 ) {
   $archive_path = '/tmp/puppet-golang.tar.gz'
 

--- a/metadata.json
+++ b/metadata.json
@@ -12,6 +12,10 @@
     {
       "name": "puppet/archive",
       "version_requirement": ">= 4.0.0 < 7.0.0"
+    },
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.18.0 < 100.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
puppet/archive already depends on puppetlabs/stdlib, so this shouldn’t pose a compatibility problem. I set the minimum version of stdlib to match what archive wants.