### PR TITLE
Defined types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Improvements
 
+* Added `golang::from_tarball` to explicitly install Go from a binary tarball.
+  This can be used to make multiple installations as root or non-root users.
 * Use [`Stdlib::HTTPUrl`][] data type for URL parameters.
 
 [`Stdlib::HTTPUrl`]: https://github.com/puppetlabs/puppetlabs-stdlib/blob/0f032a9bc557949169f565bf41e5aa1f35b17346/REFERENCE.md#stdlibhttpurl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 * Added `golang::installation` to allow multiple installs on the same system.
   Installations can be owned by root or any other user.
+* Added `golang::linked_binaries` link binaries from a Go installation into a
+  `bin` directory.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+### Features
+
+* Added `golang::installation` to allow multiple installs on the same system.
+  Installations can be owned by root or any other user.
+
 ### Improvements
 
 * Added `golang::from_tarball` to explicitly install Go from a binary tarball.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# golang
+# Easily install and update Go
+
+## Usage
+
+### Standard, single install
 
 This installs Go under `/usr/local/go/`, and symlinks the binaries into
 `/usr/local/bin/`.
-
-## Usage
 
 ``` puppet
 include golang
@@ -25,6 +27,25 @@ class { 'golang':
   ensure => absent,
 }
 ```
+
+### Multiple installs
+
+You can install Go in other places and as other users using the
+`golang::installation` defined type:
+
+``` puppet
+golang::installation { '/home/user/go-1.10.4':
+  version => '1.10.4',
+  owner   => 'user',
+  group   => 'user',
+}
+
+golang::linked_binaries { '/home/user/go-1.10.4':
+  into_bin => '/home/user/bin',
+}
+```
+
+Of course, you can remove these resources with `ensure => absent`.
 
 ## Limitations
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8,6 +8,14 @@
 
 * [`golang`](#golang): Install go in `/usr/local/go` and `/usr/local/bin`
 
+### Defined types
+
+* [`golang::from_tarball`](#golang--from_tarball): Install Go from a binary tarball
+
+### Functions
+
+* [`golang::state_file`](#golang--state_file): Figure out the default state file path for a given `$go_dir`
+
 ## Classes
 
 ### <a name="golang"></a>`golang`
@@ -102,4 +110,131 @@ Data type: `Stdlib::HTTPUrl`
 URL to actual archive.
 
 Default value: `"${source_prefix}/go${version}.${os}-${arch}.tar.gz"`
+
+## Defined types
+
+### <a name="golang--from_tarball"></a>`golang::from_tarball`
+
+Install Go from a binary tarball
+
+#### Examples
+
+##### Standard usage
+
+```puppet
+golang::from_tarball { '/usr/local/go':
+  source => 'https://go.dev/dl/go1.19.1.darwin-amd64.tar.gz',
+}
+```
+
+##### Running puppet as `user`
+
+```puppet
+golang::from_tarball { '/home/user/go/go':
+  source => 'https://go.dev/dl/go1.19.1.darwin-amd64.tar.gz',
+}
+```
+
+#### Parameters
+
+The following parameters are available in the `golang::from_tarball` defined type:
+
+* [`source`](#-golang--from_tarball--source)
+* [`ensure`](#-golang--from_tarball--ensure)
+* [`go_dir`](#-golang--from_tarball--go_dir)
+* [`owner`](#-golang--from_tarball--owner)
+* [`group`](#-golang--from_tarball--group)
+* [`mode`](#-golang--from_tarball--mode)
+* [`state_file`](#-golang--from_tarball--state_file)
+
+##### <a name="-golang--from_tarball--source"></a>`source`
+
+Data type: `Stdlib::HTTPUrl`
+
+The URL to the binary tarball to install. If the URL changes, `$path` will
+be wiped and the new tarball will be installed.
+
+##### <a name="-golang--from_tarball--ensure"></a>`ensure`
+
+Data type: `Enum[present, absent]`
+
+* `present`: Make sure Go is installed.
+* `absent`: Make sure Go is uninstalled.
+
+Default value: `present`
+
+##### <a name="-golang--from_tarball--go_dir"></a>`go_dir`
+
+Data type: `Stdlib::Unixpath`
+
+The path where the tarball should be installed. This path will be managed
+by this resource.
+
+Default value: `$name`
+
+##### <a name="-golang--from_tarball--owner"></a>`owner`
+
+Data type: `Variant[String[1], Integer[0]]`
+
+The user that should own `$go_dir`. May be a user name or a UID.
+
+Default value: `$facts['identity']['user']`
+
+##### <a name="-golang--from_tarball--group"></a>`group`
+
+Data type: `Variant[String[1], Integer[0]]`
+
+The group that should own `$go_dir`. May be a group name or a GID.
+
+Default value: `$facts['identity']['group']`
+
+##### <a name="-golang--from_tarball--mode"></a>`mode`
+
+Data type: `String[1]`
+
+The mode for `$go_dir`.
+
+Default value: `'0755'`
+
+##### <a name="-golang--from_tarball--state_file"></a>`state_file`
+
+Data type: `Stdlib::Unixpath`
+
+Where to store state information.
+
+This file will contain the URL to the tarball. If the file contents don’t
+match the URL passed in `$source`, then we know that we need to download the
+tarball and replace the installation.
+
+This defaults to a file in the same directory as `$go_dir`, but with a `.`
+prefix and a `.source_url` suffix. For example, if `$go_dir` is
+`'/usr/local/go'`, then this will default to `'/usr/local/.go.source_url'`.
+
+Default value: `golang::state_file($go_dir)`
+
+## Functions
+
+### <a name="golang--state_file"></a>`golang::state_file`
+
+Type: Puppet Language
+
+The location must be outside of `$go_dir`, and it must be writable by the
+same user (if Puppet is not being run as root).
+
+#### `golang::state_file(Stdlib::Absolutepath $go_dir)`
+
+The location must be outside of `$go_dir`, and it must be writable by the
+same user (if Puppet is not being run as root).
+
+Returns: `Stdlib::Absolutepath` Where to store the state file by default
+
+Raises:
+
+* `Puppet::Error` If `$go_dir` is `'/'` or a few other things, this will fail because there isn’t a reasonable default outside of `$go_dir` itself.
+
+##### `go_dir`
+
+Data type: `Stdlib::Absolutepath`
+
+Where Go will be installed
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -12,6 +12,7 @@
 
 * [`golang::from_tarball`](#golang--from_tarball): Install Go from a binary tarball
 * [`golang::installation`](#golang--installation): Install Go in a local directory
+* [`golang::linked_binaries`](#golang--linked_binaries): Link binaries from Go installation into a directory
 
 ### Functions
 
@@ -355,6 +356,68 @@ prefix and a `.source_url` suffix. For example, if `$go_dir` is
 `'/usr/local/go'`, then this will default to `'/usr/local/.go.source_url'`.
 
 Default value: `golang::state_file($go_dir)`
+
+### <a name="golang--linked_binaries"></a>`golang::linked_binaries`
+
+Link binaries from Go installation into a directory
+
+#### Examples
+
+##### Standard usage
+
+```puppet
+golang::linked_binaries { '/usr/local/go':
+  into_bin => '/usr/local/bin',
+}
+```
+
+##### User install
+
+```puppet
+golang::linked_binaries { '/home/user/go/go':
+  into_bin => '/home/user/bin',
+}
+```
+
+#### Parameters
+
+The following parameters are available in the `golang::linked_binaries` defined type:
+
+* [`into_bin`](#-golang--linked_binaries--into_bin)
+* [`ensure`](#-golang--linked_binaries--ensure)
+* [`go_dir`](#-golang--linked_binaries--go_dir)
+* [`binaries`](#-golang--linked_binaries--binaries)
+
+##### <a name="-golang--linked_binaries--into_bin"></a>`into_bin`
+
+Data type: `Stdlib::Unixpath`
+
+The directory to link the binaries into.
+
+##### <a name="-golang--linked_binaries--ensure"></a>`ensure`
+
+Data type: `Enum[present, absent]`
+
+* `present`: Make sure links are present.
+* `absent`: Make sure links are absent.
+
+Default value: `present`
+
+##### <a name="-golang--linked_binaries--go_dir"></a>`go_dir`
+
+Data type: `Stdlib::Unixpath`
+
+The directory where Go is installed.
+
+Default value: `$name`
+
+##### <a name="-golang--linked_binaries--binaries"></a>`binaries`
+
+Data type: `Array[String[1]]`
+
+The binaries to link.
+
+Default value: `['go', 'gofmt']`
 
 ## Functions
 

--- a/functions/state_file.pp
+++ b/functions/state_file.pp
@@ -1,0 +1,25 @@
+# @summary Figure out the default state file path for a given `$go_dir`
+#
+# The location must be outside of `$go_dir`, and it must be writable by the
+# same user (if Puppet is not being run as root).
+#
+# @param go_dir
+#   Where Go will be installed
+# @return [Stdlib::Absolutepath]
+#   Where to store the state file by default
+# @raise Puppet::Error
+#   If `$go_dir` is `'/'` or a few other things, this will fail because there
+#   isn’t a reasonable default outside of `$go_dir` itself.
+function golang::state_file(Stdlib::Absolutepath $go_dir)
+>> Stdlib::Absolutepath {
+  $base = basename($go_dir)
+  $dir = dirname($go_dir)
+
+  if $base == '/' or $base == '.' or $base == '..' {
+    fail("No reasonable default state_file for go_dir '${go_dir}'")
+  } elsif $dir == '/' {
+    "/.${base}.source_url"
+  } else {
+    "${dir}/.${base}.source_url"
+  }
+}

--- a/manifests/from_tarball.pp
+++ b/manifests/from_tarball.pp
@@ -1,0 +1,113 @@
+# @summary Install Go from a binary tarball
+#
+# @example Standard usage
+#   golang::from_tarball { '/usr/local/go':
+#     source => 'https://go.dev/dl/go1.19.1.darwin-amd64.tar.gz',
+#   }
+#
+# @example Running puppet as `user`
+#   golang::from_tarball { '/home/user/go/go':
+#     source => 'https://go.dev/dl/go1.19.1.darwin-amd64.tar.gz',
+#   }
+#
+# @param source
+#   The URL to the binary tarball to install. If the URL changes, `$path` will
+#   be wiped and the new tarball will be installed.
+# @param ensure
+#   * `present`: Make sure Go is installed.
+#   * `absent`: Make sure Go is uninstalled.
+# @param go_dir
+#   The path where the tarball should be installed. This path will be managed
+#   by this resource.
+# @param owner
+#   The user that should own `$go_dir`. May be a user name or a UID.
+# @param group
+#   The group that should own `$go_dir`. May be a group name or a GID.
+# @param mode
+#   The mode for `$go_dir`.
+# @param state_file
+#   Where to store state information.
+#
+#   This file will contain the URL to the tarball. If the file contents don’t
+#   match the URL passed in `$source`, then we know that we need to download the
+#   tarball and replace the installation.
+#
+#   This defaults to a file in the same directory as `$go_dir`, but with a `.`
+#   prefix and a `.source_url` suffix. For example, if `$go_dir` is
+#   `'/usr/local/go'`, then this will default to `'/usr/local/.go.source_url'`.
+define golang::from_tarball (
+  Stdlib::HTTPUrl                $source,
+  Enum[present, absent]          $ensure     = present,
+  Stdlib::Unixpath               $go_dir     = $name,
+  Variant[String[1], Integer[0]] $owner      = $facts['identity']['user'],
+  Variant[String[1], Integer[0]] $group      = $facts['identity']['group'],
+  String[1]                      $mode       = '0755',
+  Stdlib::Unixpath               $state_file = golang::state_file($go_dir),
+) {
+  # Used to ensure that the installation is updated when $source changes.
+  $file_ensure = $ensure ? {
+    'present' => file,
+    default   => absent,
+  }
+
+  file { $state_file:
+    ensure  => $file_ensure,
+    owner   => $owner,
+    group   => $group,
+    mode    => '0444',
+    # lint:ignore:strict_indent broken lint check
+    content => @("EOF"),
+      # This file is managed by Puppet.
+      #
+      # Any changes will cause Go to be reinstalled on the next Puppet run and
+      # this file to be overwritten.
+      ${source}
+      | EOF
+    # lint:endignore
+  }
+
+  $directory_ensure = $ensure ? {
+    'present' => directory,
+    default   => absent,
+  }
+
+  file { $go_dir:
+    ensure => $directory_ensure,
+    force  => true,
+    owner  => $owner,
+    group  => $group,
+    mode   => $mode,
+  }
+
+  if $ensure == present {
+    $encoded_go_dir = $go_dir.regsubst('/', '_', 'G')
+    $archive_path = "/tmp/puppet-golang${encoded_go_dir}.tar.gz"
+
+    # If the $go_dir/bin directory exists, archive won't update it. Also, we
+    # want to remove any files that are not present in the new version.
+    exec { "dp/golang refresh go installation at ${go_dir}":
+      command     => ['rm', '-rf', $go_dir],
+      path        => ['/usr/local/bin', '/usr/bin', '/bin'],
+      user        => $facts['identity']['user'],
+      refreshonly => true,
+      subscribe   => File[$state_file],
+      before      => File[$go_dir],
+      notify      => Archive[$archive_path],
+    }
+
+    include archive
+
+    archive { $archive_path:
+      ensure        => present,
+      extract       => true,
+      extract_path  => $go_dir,
+      extract_flags => '--strip-components 1 -xf',
+      user          => $owner,
+      group         => $group,
+      source        => $source,
+      creates       => "${go_dir}/bin",
+      cleanup       => true,
+      require       => File[$go_dir],
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,12 +1,10 @@
 # @summary Install go in `/usr/local/go` and `/usr/local/bin`
 #
-# `/usr/local/share/` *must* exist.
-#
 # Most people will not need to change any parameter other than `$version`.
 #
 # @param ensure
-#   * `present`: Make sure go is installed.
-#   * `absent`: Make sure go is uninstalled.
+#   * `present`: Make sure Go is installed.
+#   * `absent`: Make sure Go is uninstalled.
 # @param version
 #   The version of Go to install. You can find the latest version number at
 #   https://go.dev/dl/
@@ -19,18 +17,18 @@
 # @param arch
 #   The architecture to use to determine what archive to download.
 # @param source
-#   URL to actual archive.
+#   URL of a binary tarball. If this is set it overrides everything else.
 class golang (
-  Enum[present, absent] $ensure        = present,
-  String[1]             $version       = '1.19.1',
-  Array[String[1]]      $link_binaries = ['go', 'gofmt'],
-  Stdlib::HTTPUrl       $source_prefix = 'https://go.dev/dl',
-  String[1]             $os            = $facts['kernel'] ? {
+  Enum[present, absent]     $ensure        = present,
+  String[1]                 $version       = '1.19.1',
+  Array[String[1]]          $link_binaries = ['go', 'gofmt'],
+  Stdlib::HTTPUrl           $source_prefix = 'https://go.dev/dl',
+  String[1]                 $os            = $facts['kernel'] ? {
     'Linux'  => 'linux',
     'Darwin' => 'darwin',
     default  => $facts['kernel'] # lint:ignore:parameter_documentation broken
   },
-  String[1]             $arch          = $facts['os']['hardware'] ? {
+  String[1]                 $arch          = $facts['os']['hardware'] ? {
     undef     => 'amd64', # Assume amd64 if os.hardware is missing.
     'aarch64' => 'arm64',
     'armv7l'  => 'armv6l',
@@ -38,11 +36,21 @@ class golang (
     'x86_64'  => 'amd64',
     default   => $facts['os']['hardware'], # lint:ignore:parameter_documentation broken
   },
-  Stdlib::HTTPUrl       $source        = "${source_prefix}/go${version}.${os}-${arch}.tar.gz",
+  Optional[Stdlib::HTTPUrl] $source        = undef,
 ) {
-  golang::from_tarball { '/usr/local/go':
-    ensure => $ensure,
-    source => $source,
+  if $source == undef {
+    golang::installation { '/usr/local/go':
+      ensure        => $ensure,
+      version       => $version,
+      source_prefix => $source_prefix,
+      os            => $os,
+      arch          => $arch,
+    }
+  } else {
+    golang::from_tarball { '/usr/local/go':
+      ensure => $ensure,
+      source => $source,
+    }
   }
 
   $link_ensure = $ensure ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,16 +53,9 @@ class golang (
     }
   }
 
-  $link_ensure = $ensure ? {
-    'present' => link,
-    default   => absent,
-  }
-
-  $link_binaries.each |$binary| {
-    file { "/usr/local/bin/${binary}":
-      ensure  => $link_ensure,
-      target  => "/usr/local/go/bin/${binary}",
-      require => Golang::From_tarball['/usr/local/go'],
-    }
+  golang::linked_binaries { '/usr/local/go':
+    ensure   => $ensure,
+    into_bin => '/usr/local/bin',
+    binaries => $link_binaries,
   }
 }

--- a/manifests/installation.pp
+++ b/manifests/installation.pp
@@ -1,0 +1,75 @@
+# @summary Install Go in a local directory
+#
+# @example Simple
+#   golang::installation { '/usr/local/go': }
+#
+# @example For a user
+#   golang::installation { '/home/user/go/go':
+#     version => '1.10.4',
+#     owner   => 'user',
+#     group   => 'user',
+#   }
+#
+# @param ensure
+#   * `present`: Make sure Go is installed.
+#   * `absent`: Make sure Go is uninstalled.
+# @param go_dir
+#   The path where Go should be installed. This path will be managed by
+#   [`golang::from_tarball`](#golang--from_tarball).
+# @param version
+#   The version of Go to install. You can find the latest version number at
+#   https://go.dev/dl/
+# @param source_prefix
+#   URL to directory that contains the archive to download.
+# @param os
+#   The OS to use to determine what archive to download.
+# @param arch
+#   The architecture to use to determine what archive to download.
+# @param owner
+#   The user that should own `$go_dir`. May be a user name or a UID.
+# @param group
+#   The group that should own `$go_dir`. May be a group name or a GID.
+# @param mode
+#   The mode for `$go_dir`.
+# @param state_file
+#   Where to store state information.
+#
+#   This file will contain the URL to the tarball. If the file contents don’t
+#   match the URL we generate, then we know that we need to download the tarball
+#   and replace the installation.
+#
+#   This defaults to a file in the same directory as `$go_dir`, but with a `.`
+#   prefix and a `.source_url` suffix. For example, if `$go_dir` is
+#   `'/usr/local/go'`, then this will default to `'/usr/local/.go.source_url'`.
+define golang::installation (
+  Enum[present, absent]          $ensure        = present,
+  Stdlib::Unixpath               $go_dir        = $name,
+  String[1]                      $version       = '1.19.1',
+  Stdlib::HTTPUrl                $source_prefix = 'https://go.dev/dl',
+  String[1]                      $os            = $facts['kernel'] ? {
+    'Linux'  => 'linux',
+    'Darwin' => 'darwin',
+    default  => $facts['kernel'] # lint:ignore:parameter_documentation broken
+  },
+  String[1]                      $arch          = $facts['os']['hardware'] ? {
+    undef     => 'amd64', # Assume amd64 if os.hardware is missing.
+    'aarch64' => 'arm64',
+    'armv7l'  => 'armv6l',
+    'i686'    => '386',
+    'x86_64'  => 'amd64',
+    default   => $facts['os']['hardware'], # lint:ignore:parameter_documentation broken
+  },
+  Variant[String[1], Integer[0]] $owner         = $facts['identity']['user'],
+  Variant[String[1], Integer[0]] $group         = $facts['identity']['group'],
+  String[1]                      $mode          = '0755',
+  Stdlib::Unixpath               $state_file    = golang::state_file($go_dir),
+) {
+  golang::from_tarball { $go_dir:
+    ensure     => $ensure,
+    source     => "${source_prefix}/go${version}.${os}-${arch}.tar.gz",
+    owner      => $owner,
+    group      => $group,
+    mode       => $mode,
+    state_file => $state_file,
+  }
+}

--- a/manifests/linked_binaries.pp
+++ b/manifests/linked_binaries.pp
@@ -1,0 +1,40 @@
+# @summary Link binaries from Go installation into a directory
+#
+# @example Standard usage
+#   golang::linked_binaries { '/usr/local/go':
+#     into_bin => '/usr/local/bin',
+#   }
+#
+# @example User install
+#   golang::linked_binaries { '/home/user/go/go':
+#     into_bin => '/home/user/bin',
+#   }
+#
+# @param into_bin
+#   The directory to link the binaries into.
+# @param ensure
+#   * `present`: Make sure links are present.
+#   * `absent`: Make sure links are absent.
+# @param go_dir
+#   The directory where Go is installed.
+# @param binaries
+#   The binaries to link.
+define golang::linked_binaries (
+  Stdlib::Unixpath      $into_bin,
+  Enum[present, absent] $ensure   = present,
+  Stdlib::Unixpath      $go_dir   = $name,
+  Array[String[1]]      $binaries = ['go', 'gofmt'],
+) {
+  $link_ensure = $ensure ? {
+    'present' => link,
+    default   => absent,
+  }
+
+  $binaries.each |$binary| {
+    file { "${into_bin}/${binary}":
+      ensure  => $link_ensure,
+      target  => "${go_dir}/bin/${binary}",
+      require => Golang::From_tarball[$go_dir],
+    }
+  }
+}

--- a/spec/acceptance/golang_installation_spec.rb
+++ b/spec/acceptance/golang_installation_spec.rb
@@ -1,0 +1,256 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'defined type golang::installation' do
+  context 'multiple root installs with linked_binaries' do
+    it do
+      idempotent_apply(<<~'PUPPET')
+        golang::installation { '/opt/go1.10.4':
+          version => '1.10.4',
+        }
+        golang::installation { '/opt/go1.19.1':
+          version => '1.19.1',
+        }
+        golang::linked_binaries { '/opt/go1.19.1':
+          into_bin => '/usr/local/bin',
+        }
+      PUPPET
+    end
+
+    ['1.10.4', '1.19.1'].each do |version|
+      describe file("/opt/go#{version}") do
+        it { is_expected.to be_directory }
+        it { is_expected.to be_owned_by 'root' }
+      end
+
+      describe file("/opt/go#{version}/bin/go") do
+        it { is_expected.to be_file }
+        it { is_expected.to be_executable }
+        it { is_expected.to be_owned_by 'root' }
+      end
+
+      describe command("/opt/go#{version}/bin/go version") do
+        its(:stdout) { is_expected.to start_with("go version go#{version} ") }
+        its(:stderr) { is_expected.to eq '' }
+        its(:exit_status) { is_expected.to eq 0 }
+      end
+    end
+
+    describe file('/usr/local/bin/go') do
+      it { is_expected.to be_symlink }
+      it { is_expected.to be_linked_to '/opt/go1.19.1/bin/go' }
+    end
+  end
+
+  context 'multiple root installs with mixed ensure and linked_binaries' do
+    it do
+      idempotent_apply(<<~'PUPPET')
+        golang::installation { '/opt/go1.10.4':
+          version => '1.10.4',
+        }
+        golang::installation { '/opt/go1.19.1':
+          ensure => absent,
+        }
+        golang::linked_binaries { '/opt/go1.10.4':
+          into_bin => '/usr/local/bin',
+        }
+      PUPPET
+    end
+
+    describe file('/opt/go1.10.4/bin/go') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_executable }
+      it { is_expected.to be_owned_by 'root' }
+    end
+
+    describe file('/opt/go1.19.1') do
+      it { is_expected.not_to exist }
+    end
+
+    describe file('/usr/local/bin/go') do
+      it { is_expected.to be_symlink }
+      it { is_expected.to be_linked_to '/opt/go1.10.4/bin/go' }
+    end
+
+    describe command('/usr/local/bin/go version') do
+      its(:stdout) { is_expected.to start_with('go version go1.10.4 ') }
+      its(:stderr) { is_expected.to eq '' }
+      its(:exit_status) { is_expected.to eq 0 }
+    end
+  end
+
+  context 'multiple root uninstalls with linked_binaries' do
+    it do
+      idempotent_apply(<<~'PUPPET')
+        golang::installation { '/opt/go1.10.4':
+          ensure => absent,
+        }
+        golang::installation { '/opt/go1.19.1':
+          ensure => absent,
+        }
+        golang::linked_binaries { '/opt/go1.10.4':
+          ensure   => absent,
+          into_bin => '/usr/local/bin',
+        }
+      PUPPET
+    end
+
+    describe file('/opt/go1.10.4') do
+      it { is_expected.not_to exist }
+    end
+
+    describe file('/opt/go1.19.1') do
+      it { is_expected.not_to exist }
+    end
+
+    describe file('/usr/local/bin/go') do
+      it { is_expected.not_to exist }
+    end
+  end
+
+  context 'multiple user installs with linked_binaries' do
+    it do
+      idempotent_apply(<<~'PUPPET')
+        golang::installation { '/home/user/go1.10.4':
+          version => '1.10.4',
+          owner   => 'user',
+          group   => 'user',
+          mode    => '0700',
+        }
+
+        golang::installation { '/home/user/go1.19.1':
+          version => '1.19.1',
+          owner   => 'user',
+          group   => 'user',
+          mode    => '0700',
+        }
+
+        golang::linked_binaries { '/home/user/go1.19.1':
+          into_bin => '/home/user/bin',
+        }
+
+        group { 'user': }
+        user { 'user':
+          home       => '/home/user',
+          gid        => 'user',
+          managehome => true,
+        }
+
+        file { '/home/user/bin':
+          ensure => directory,
+          owner  => 'user',
+          group  => 'user',
+          mode   => '0755',
+        }
+      PUPPET
+    end
+
+    ['1.10.4', '1.19.1'].each do |version|
+      describe file("/home/user/go#{version}") do
+        it { is_expected.to be_directory }
+        it { is_expected.to be_owned_by 'user' }
+        it { is_expected.to be_grouped_into 'user' }
+        it { is_expected.to be_mode 700 } # WTF converted to octal
+      end
+
+      describe file("/home/user/go#{version}/bin/go") do
+        it { is_expected.to be_file }
+        it { is_expected.to be_owned_by 'user' }
+        it { is_expected.to be_grouped_into 'user' }
+        it { is_expected.to be_mode 755 } # WTF converted to octal
+      end
+
+      describe command("/home/user/go#{version}/bin/go version") do
+        its(:stdout) { is_expected.to start_with("go version go#{version} ") }
+        its(:stderr) { is_expected.to eq '' }
+        its(:exit_status) { is_expected.to eq 0 }
+      end
+    end
+
+    describe file('/home/user/bin/go') do
+      it { is_expected.to be_symlink }
+      it { is_expected.to be_linked_to '/home/user/go1.19.1/bin/go' }
+    end
+  end
+
+  context 'multiple user installs with mixed ensure and linked_binaries' do
+    it do
+      idempotent_apply(<<~'PUPPET')
+        golang::installation { '/home/user/go1.10.4':
+          version => '1.10.4',
+          owner   => 'user',
+          group   => 'user',
+        }
+        golang::installation { '/home/user/go1.19.1':
+          ensure => absent,
+        }
+        golang::linked_binaries { '/home/user/go1.10.4':
+          into_bin => '/home/user/bin',
+        }
+      PUPPET
+    end
+
+    describe file('/home/user/go1.10.4') do
+      it { is_expected.to be_directory }
+      it { is_expected.to be_owned_by 'user' }
+      it { is_expected.to be_grouped_into 'user' }
+      it { is_expected.to be_mode 755 } # WTF converted to octal
+    end
+
+    describe file('/home/user/go1.10.4/bin/go') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_owned_by 'user' }
+      it { is_expected.to be_grouped_into 'user' }
+      it { is_expected.to be_mode 755 } # WTF converted to octal
+    end
+
+    describe file('/home/user/go1.19.1') do
+      it { is_expected.not_to exist }
+    end
+
+    describe file('/home/user/bin/go') do
+      it { is_expected.to be_symlink }
+      it { is_expected.to be_linked_to '/home/user/go1.10.4/bin/go' }
+    end
+
+    describe command('/home/user/bin/go version') do
+      its(:stdout) { is_expected.to start_with('go version go1.10.4 ') }
+      its(:stderr) { is_expected.to eq '' }
+      its(:exit_status) { is_expected.to eq 0 }
+    end
+  end
+
+  context 'multiple user uninstalls with linked_binaries' do
+    it do
+      idempotent_apply(<<~'PUPPET')
+        golang::installation { '/home/user/go1.10.4':
+          ensure => absent,
+          owner  => 'user',
+          group  => 'user',
+        }
+        golang::installation { '/home/user/go1.19.1':
+          ensure => absent,
+          owner  => 'user',
+          group  => 'user',
+        }
+        golang::linked_binaries { '/home/user/go1.10.4':
+          ensure   => absent,
+          into_bin => '/home/user/bin',
+        }
+      PUPPET
+    end
+
+    describe file('/home/user/go1.10.4') do
+      it { is_expected.not_to exist }
+    end
+
+    describe file('/home/user/go1.19.1') do
+      it { is_expected.not_to exist }
+    end
+
+    describe file('/home/user/bin/go') do
+      it { is_expected.not_to exist }
+    end
+  end
+end

--- a/spec/acceptance/golang_spec.rb
+++ b/spec/acceptance/golang_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper_acceptance'
 
-describe 'golang' do
+describe 'class golang' do
   context 'install with a specific version' do
     it do
       idempotent_apply(<<~'END')
@@ -29,7 +29,7 @@ describe 'golang' do
     end
 
     describe command('/usr/local/bin/go version') do
-      its(:stdout) { is_expected.to match(%r{\Ago version go1.10.4 }) }
+      its(:stdout) { is_expected.to start_with('go version go1.10.4 ') }
       its(:stderr) { is_expected.to eq '' }
       its(:exit_status) { is_expected.to eq 0 }
     end
@@ -55,7 +55,7 @@ describe 'golang' do
     end
 
     describe command('/usr/local/bin/go version') do
-      its(:stdout) { is_expected.to match(%r{\Ago version }) }
+      its(:stdout) { is_expected.to start_with('go version ') }
       its(:stderr) { is_expected.to eq '' }
       its(:exit_status) { is_expected.to eq 0 }
     end

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -6,3 +6,9 @@ ipaddress: "172.16.254.254"
 ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"
+identity:
+  gid: 0
+  group: "wheel"
+  privileged: true
+  uid: 0
+  user: "root"

--- a/spec/defines/from_tarball_spec.rb
+++ b/spec/defines/from_tarball_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'golang::from_tarball' do
+  let(:title) { '/usr/local/go' }
+  let(:params) { { source: 'https://go.dev/dl/foobar.tar.gz' } }
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+      it { is_expected.to contain_file('/usr/local/.go.source_url') }
+    end
+  end
+end

--- a/spec/defines/installation_spec.rb
+++ b/spec/defines/installation_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'golang::installation' do
+  let(:title) { '/usr/local/go' }
+  let(:params) { {} }
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/defines/linked_binaries_spec.rb
+++ b/spec/defines/linked_binaries_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'golang::linked_binaries' do
+  let(:pre_condition) { <<~'PUPPET' }
+    golang::from_tarball { '/usr/local/go':
+      source => 'https://go.dev/dl/foo.tar.gz',
+    }
+  PUPPET
+
+  let(:title) { '/usr/local/go' }
+  let(:params) { { into_bin: '/usr/local/bin' } }
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/functions/state_file_spec.rb
+++ b/spec/functions/state_file_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'golang::state_file' do
+  it { runs_with('/usr/local/go', returns: '/usr/local/.go.source_url') }
+  it { runs_with('/go', returns: '/.go.source_url') }
+  it { runs_with('/./go', returns: '/./.go.source_url') }
+  it { runs_with('/../go', returns: '/../.go.source_url') }
+  it { runs_with('/...', returns: '/.....source_url') }
+
+  it { runs_with('/', fails: %r{No reasonable default state_file}) }
+  it { runs_with('/.', fails: %r{No reasonable default state_file}) }
+  it { runs_with('/..', fails: %r{No reasonable default state_file}) }
+end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# rspec-puppet function testing makes lines too long
+#
+# @params *args
+#   Parameters to function
+# @params returns
+#   Optional. The expected return value.
+# @params fails
+#   Optional. A string or regexp to match an expected error.
+# @params block
+#   Optional. Is passed the result of the check so far (with `and_return` and
+#   `and_raise_error` if specified) and is expected to return the check.
+#
+#   ```ruby
+#   runs_with('bad') { |check| check.and_raise_error(ArgumentError) }
+#   ```
+def runs_with(*args, returns: :nocheck, fails: :nocheck)
+  check = run.with_params(*args)
+
+  if returns != :nocheck
+    check = check.and_return(returns)
+  end
+
+  if fails != :nocheck
+    check = check.and_raise_error(StandardError, fails)
+  end
+
+  if block_given?
+    check = yield check
+  end
+
+  is_expected.to check
+end


### PR DESCRIPTION
Adds three defined types to do the real work of installing Go.

This allows multiple go installations on the same system, possibly owned by different users. It should also allow the module to be used by a non-root user.