### PR TITLE
fix reference links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+### Improvements
+
+* Added more links to [REFERENCE.md][] from [README.md][] to make it easier to
+  find reference documentation.
+
+### Bug fixes
+
+* The Hiera example in [README.md][] referenced the deprecated `golang::version`
+  instead of `golang::ensure`.
+
+[README.md]: README.md
+[REFERENCE.md]: REFERENCE.md
+
 ## Release 1.2.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 
 ### Bug fixes
 
+* Anchor links seem to be broken on the Forge, so we now update links to
+  [REFERENCE.md][] and other markdown files to point to GitHub when making a
+  release.
 * The Hiera example in [README.md][] referenced the deprecated `golang::version`
   instead of `golang::ensure`.
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ diferent versions, and running [Puppet as a non-root user][non-root].
 
 ### Standard, single install
 
-This installs Go under `/usr/local/go/`, and symlinks the binaries into
-`/usr/local/bin/`.
+The [`golang` class][`golang`] installs Go under `/usr/local/go/`, and symlinks
+the binaries into `/usr/local/bin/`.
 
 ``` puppet
 include golang
@@ -20,8 +20,8 @@ include golang
 
 By default it installs the latest version but never upgrades it after the
 initial installation. You can set it to automatically upgrade by passing
-`latest` to `ensure`, either with hiera (`golang::version: latest`), or with
-a class declaration:
+`latest` to [`ensure`][$golang::ensure], either with [hiera][]
+(`golang::ensure: latest`), or with a class declaration:
 
 ``` puppet
 class { 'golang':
@@ -29,7 +29,8 @@ class { 'golang':
 }
 ```
 
-You may force it to install a specific version by passing it to `ensure`:
+You may force it to install a specific version by passing it to
+[`ensure`][$golang::ensure]:
 
 ``` puppet
 class { 'golang':
@@ -37,7 +38,7 @@ class { 'golang':
 }
 ```
 
-Of course, you can also use `ensure` to uninstall Go:
+Of course, you can also use [`ensure`][$golang::ensure] to uninstall Go:
 
 ``` puppet
 class { 'golang':
@@ -48,7 +49,8 @@ class { 'golang':
 ### Multiple installs
 
 You can install Go in other places and as other users using the
-`golang::installation` defined type:
+[`golang::installation`][] defined type, and you can link its binaries into
+a `bin` directory with [`golang::linked_binaries`][]:
 
 ``` puppet
 golang::installation { '/home/user/go-1.19.1':
@@ -62,13 +64,15 @@ golang::linked_binaries { '/home/user/go-1.19.1':
 }
 ```
 
-To install the latest version, set `ensure => latest` on `golang::installation`.
-To remove the installation or symlinks, just use `ensure => absent`.
+To install the latest version, set [`ensure => latest`][$g::i::ensure] on
+[`golang::installation`][]. To remove the installation or symlinks, just use
+`ensure => absent`.
 
 ### Running Puppet as a non-root user
 
 You can use the defined types to install Go even when running as a non-root
-user. `owner` and `group` default to the user and group running Puppet:
+user. [`owner`][$g::i::owner] and [`group`][$g::i::group] default to the user
+and group running Puppet:
 
 ``` puppet
 golang::installation { '/home/me/go':
@@ -86,9 +90,19 @@ This does not support Windows.
 
 ## Reference
 
-There is specific documentation for individual parameters in
-[REFERENCE.md](REFERENCE.md). That file is generated with:
+There is specific documentation for individual parameters in [REFERENCE.md][].
+That file is generated with:
 
 ```
 pdk bundle exec puppet strings generate --format markdown
 ```
+
+[REFERENCE.md]: REFERENCE.md
+[`golang`]: REFERENCE.md#golang
+[$golang::ensure]: REFERENCE.md#-golang--ensure
+[`golang::installation`]: REFERENCE.md#golang--installation
+[$g::i::ensure]: REFERENCE.md#-golang--installation--ensure
+[$g::i::owner]: REFERENCE.md#-golang--installation--owner
+[$g::i::group]: REFERENCE.md#-golang--installation--group
+[`golang::linked_binaries`]: REFERENCE.md#golang--linked_binaries
+[hiera]: https://puppet.com/docs/puppet/latest/hiera.html

--- a/release.rb
+++ b/release.rb
@@ -3,20 +3,24 @@
 # rubocop:disable Style/WhileUntilModifier
 
 require 'getoptlong'
+require 'json'
 require 'rdoc'
 require 'shellwords'
 require 'uri'
 
 def usage
   <<~'TEXT'
-    ./release.rb [--forge-token TOKEN] [--dry-run] VERSION SUMMARY
+    ./release.rb [--forge-token TOKEN] [options...] VERSION SUMMARY
 
       Make a release.
 
+      VERSION   the version to release. Will be set in metadata.json
+      SUMMARY   the one line summary of the release
+
       --forge-token TOKEN  may be left off if $PDK_FORGE_TOKEN is set
       --dry-run            don’t commit or publish any changes
-      VERSION              the version to release. Will be set in metadata.json
-      SUMMARY              the one line summary of the release
+      --just-forge-update  just update files as if we were going to build a
+                           package to upload to the Forge
 
     ./release.rb --help
 
@@ -35,20 +39,24 @@ opts = GetoptLong.new(
   [ '--help', '-h', GetoptLong::NO_ARGUMENT ],
   [ '--dry-run', '-n', GetoptLong::NO_ARGUMENT ],
   [ '--forge-token', '-t', GetoptLong::REQUIRED_ARGUMENT ],
+  [ '--just-forge-update', GetoptLong::NO_ARGUMENT ],
 )
 
 forge_token = ENV['PDK_FORGE_TOKEN']
 dry_run = false
+just_forge_update = false
 
 opts.each do |opt, arg|
   case opt
   when '--help'
     print usage
     exit 0
-  when '--dry-run'
-    dry_run = true
   when '--forge-token'
     forge_token = arg
+  when '--dry-run'
+    dry_run = true
+  when '--just-forge-update'
+    just_forge_update = true
   end
 end
 
@@ -91,7 +99,7 @@ def extract_changes_for_release!(changelog, version)
   end
 
   # Trim blank lines off end of release notes
-  while release_notes.last.match?(%r{\A\s*\z})
+  while %r{\A\s*\z}.match?(release_notes.last)
     release_notes.pop
   end
 
@@ -112,7 +120,7 @@ def insert_main_branch_header!(changelog)
   line.insert(0, "## main branch\n\n")
 end
 
-def fix_links(path)
+def fix_links(root, path)
   puts "Fixing links in #{path} for Forge"
   lines = IO.readlines(path).map do |line|
     if (match = line.match(%r{\A\[(.+?)\]:\s*(.+)\Z}))
@@ -120,16 +128,7 @@ def fix_links(path)
       uri = URI(match[2])
 
       unless uri.absolute? || !uri.host.nil?
-        case uri.path
-        when 'CHANGELOG.md'
-          uri.path = 'changelog'
-        when 'README.md'
-          uri.path = 'readme'
-        when 'REFERENCE.md'
-          uri.path = 'reference'
-        when 'LICENSE'
-          uri.path = 'license'
-        end
+        uri = root + uri
       end
 
       "[#{name}]: #{uri}\n"
@@ -146,6 +145,14 @@ def update_metadata(version)
   metadata = IO.read('metadata.json')
   metadata.sub!(%r{("version"\s*:\s*)"[0-9.]+"}, %(\\1"#{version}"))
   IO.write('metadata.json', metadata)
+end
+
+# Update files for the Forge
+def update_for_forge(metadata)
+  root_uri = URI("#{metadata['source']}/blob/v#{metadata['version']}/")
+  fix_links(root_uri, 'CHANGELOG.md')
+  fix_links(root_uri, 'README.md')
+  fix_links(root_uri, 'REFERENCE.md')
 end
 
 def run(command, *args, dry_run: false)
@@ -190,6 +197,12 @@ puts "Updating CHANGELOG.md with release #{version}"
 File.write('CHANGELOG.md', changelog.join(''))
 
 update_metadata(version)
+metadata = JSON.parse(File.read('metadata.json'))
+
+if just_forge_update
+  update_for_forge(metadata)
+  exit(0)
+end
 
 run('git', 'add', 'CHANGELOG.md', 'metadata.json')
 
@@ -205,10 +218,7 @@ run('git', 'tag', "v#{version}", '-sm', <<~MSG.chomp, dry_run: dry_run)
   #{release_notes}
 MSG
 
-# Update files for the Forge
-fix_links('CHANGELOG.md')
-fix_links('README.md')
-fix_links('REFERENCE.md')
+update_for_forge(metadata)
 
 run('pdk', 'build', '--force')
 run('pdk', 'release', 'publish', dry_run: dry_run)


### PR DESCRIPTION
- README.md: add links to REFERENCE.md.
- release.rb: update links on Forge to point to GitHub
- Kludge: unwrap soft line breaks in unordered lists in release notes for GitHub releases.
