### PR TITLE
Add checks for out-of-date REFERENCE.md

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -21,6 +21,10 @@ jobs:
     - run: gem install --no-document --minimal-deps pdk
     - run: pdk validate
 
+    - run: pdk bundle exec puppet strings generate --format markdown
+    - name: Confirm REFERENCE.md is up-to-date
+      run: git diff --color --exit-code
+
     - run: pdk update --force
     - name: Confirm PDK update does nothing
       run: git diff --color --exit-code

--- a/.sync.yml
+++ b/.sync.yml
@@ -14,9 +14,3 @@ spec/default_facts.yml:
       privileged: true
       uid: 0
       user: "root"
-
-.github/workflows/pr-checks.yaml:
-  validate-REFERENCE.md: false
-
-release.rb:
-  validate-REFERENCE.md: false

--- a/metadata.json
+++ b/metadata.json
@@ -85,5 +85,5 @@
   ],
   "pdk-version": "2.6.1",
   "template-url": "https://github.com/danielparks/pdk-templates#main",
-  "template-ref": "heads/main-0-gb75995f"
+  "template-ref": "heads/main-0-g4789b4a"
 }

--- a/release.rb
+++ b/release.rb
@@ -244,6 +244,11 @@ end
 
 run('git', 'add', 'CHANGELOG.md', 'metadata.json')
 
+puts 'Confirming that REFERENCE.md is up-to-date'
+run('pdk', 'bundle', 'exec', 'puppet', 'strings', 'generate',
+  '--format', 'markdown')
+confirm_no_changes
+
 puts 'Confirming that pdk update does nothing'
 run('pdk', 'update', '--force')
 confirm_no_changes


### PR DESCRIPTION
The pre-release version of Puppet Strings I was using to generate REFERENCE.md has been released, so this enables automatic checks that the file is up-to-date.