### PR TITLE
PDK update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,30 +14,29 @@ def location_for(place_or_version, fake_version = nil)
 end
 
 group :development do
-  gem "json", '= 2.1.0',                               require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                               require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.5.1',                               require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.6.1',                               require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.6.3',                               require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "voxpupuli-puppet-lint-plugins", '~> 3.1',       require: false
-  gem "facterdb", '~> 1.18',                           require: false
-  gem "metadata-json-lint", '>= 2.0.2', '< 4.0.0',     require: false
-  gem "puppetlabs_spec_helper", '>= 3.0.0', '< 5.0.0', require: false
-  gem "rspec-puppet-facts", '~> 2.0',                  require: false
-  gem "codecov", '~> 0.2',                             require: false
-  gem "dependency_checker", '~> 0.2',                  require: false
-  gem "parallel_tests", '~> 3.4',                      require: false
-  gem "pry", '~> 0.10',                                require: false
-  gem "simplecov-console", '~> 0.5',                   require: false
-  gem "puppet-debugger", '~> 1.0',                     require: false
-  gem "rubocop", '= 1.6.1',                            require: false
-  gem "rubocop-performance", '= 1.9.1',                require: false
-  gem "rubocop-rspec", '= 2.0.1',                      require: false
-  gem "rb-readline", '= 0.5.5',                        require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-lint-legacy_facts-check",                require: false
+  gem "json", '= 2.1.0',                           require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.3.0',                           require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.5.1',                           require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.1',                           require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.3',                           require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "voxpupuli-puppet-lint-plugins", '~> 4.0',   require: false
+  gem "facterdb", '~> 1.18',                       require: false
+  gem "metadata-json-lint", '>= 2.0.2', '< 4.0.0', require: false
+  gem "puppetlabs_spec_helper", '~> 5.0',          require: false
+  gem "rspec-puppet-facts", '~> 2.0',              require: false
+  gem "codecov", '~> 0.2',                         require: false
+  gem "dependency_checker", '~> 0.2',              require: false
+  gem "parallel_tests", '= 3.12.1',                require: false
+  gem "pry", '~> 0.10',                            require: false
+  gem "simplecov-console", '~> 0.5',               require: false
+  gem "puppet-debugger", '~> 1.0',                 require: false
+  gem "rubocop", '= 1.6.1',                        require: false
+  gem "rubocop-performance", '= 1.9.1',            require: false
+  gem "rubocop-rspec", '= 2.0.1',                  require: false
+  gem "rb-readline", '= 0.5.5',                    require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :system_tests do
-  gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby]
+  gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby, :x64_mingw]
   gem "serverspec", '~> 2.41',    require: false
 end
 

--- a/metadata.json
+++ b/metadata.json
@@ -83,7 +83,7 @@
     "go",
     "golang"
   ],
-  "pdk-version": "2.6.1",
+  "pdk-version": "2.7.0",
   "template-url": "https://github.com/danielparks/pdk-templates#main",
-  "template-ref": "heads/main-0-g4789b4a"
+  "template-ref": "heads/main-0-gce583f5"
 }


### PR DESCRIPTION
Just a periodic update to keep things in sync with the latest PDK release.

---

I’m getting failures like the below on my laptop. They seem to be corrected by allowing legacy facts.

```
❯ pdk bundle update       
pdk (INFO): Using Ruby 2.7.7
pdk (INFO): Using Puppet 7.22.0
The dependency rb-readline (= 0.5.5) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mswin32, x86-mingw32, x64-mingw32. To add those platforms to the bundle, run `bundle lock --add-platform x86-mswin32 x86-mingw32 x64-mingw32`.
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies....
Bundler could not find compatible versions for gem "puppet":
  In Gemfile:
    puppet (= 7.22.0)

    puppet_litmus (< 1.0.0) was resolved to 0.34.6, which depends on
      bolt (~> 3.0) was resolved to 3.27.1, which depends on
        puppet (>= 6.18.0)

    puppet-debugger (~> 1.0) was resolved to 1.3.0, which depends on
      puppet (>= 5.5)

    rspec-puppet-facts (~> 2.0) was resolved to 2.0.5, which depends on
      puppet

Bundler could not find compatible versions for gem "puppet-lint":
  In Gemfile:
    puppet-lint-legacy_facts-check was resolved to 1.0.2, which depends on
      puppet-lint (~> 2.0)

    voxpupuli-puppet-lint-plugins (~> 4.0) was resolved to 4.0.0, which depends on
      puppet-lint (~> 3.1)

Bundler could not find compatible versions for gem "r10k":
  In Gemfile:
    puppet_litmus (< 1.0.0) was resolved to 0.34.6, which depends on
      bolt (~> 3.0) was resolved to 3.27.1, which depends on
        r10k (~> 3.10)

    puppet_litmus (< 1.0.0) was resolved to 0.34.6, which depends on
      r10k (= 3.15.1)

Bundler could not find compatible versions for gem "rubocop":
  In Gemfile:
    rubocop (= 1.6.1)

    rubocop-performance (= 1.9.1) was resolved to 1.9.1, which depends on
      rubocop (>= 0.90.0, < 2.0)

    rubocop-rspec (= 2.0.1) was resolved to 2.0.1, which depends on
      rubocop (~> 1.0)
```