### PR TITLE
PDK update: release.rb --no-acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+No functional changes. This release is solely to keep the released module from
+getting too far out of sync with git after multiple `pdk update`s.
+
 ## Release 1.2.2
 
 ### Bug fixes

--- a/metadata.json
+++ b/metadata.json
@@ -85,5 +85,5 @@
   ],
   "pdk-version": "2.7.0",
   "template-url": "https://github.com/danielparks/pdk-templates#main",
-  "template-ref": "heads/main-0-gce583f5"
+  "template-ref": "heads/main-0-g98cb58a"
 }

--- a/release.rb
+++ b/release.rb
@@ -22,6 +22,7 @@ def usage
       --dry-run            don’t commit or publish any changes
       --just-forge-update  just update files as if we were going to build a
                            package to upload to the Forge
+      --no-acceptance      skip acceptance tests
 
     ./release.rb --help
 
@@ -41,11 +42,13 @@ opts = GetoptLong.new(
   [ '--dry-run', '-n', GetoptLong::NO_ARGUMENT ],
   [ '--forge-token', '-t', GetoptLong::REQUIRED_ARGUMENT ],
   [ '--just-forge-update', GetoptLong::NO_ARGUMENT ],
+  [ '--no-acceptance', GetoptLong::NO_ARGUMENT ],
 )
 
 forge_token = ENV['PDK_FORGE_TOKEN']
 dry_run = false
 just_forge_update = false
+run_acceptance = true
 
 opts.each do |opt, arg|
   case opt
@@ -58,6 +61,8 @@ opts.each do |opt, arg|
     dry_run = true
   when '--just-forge-update'
     just_forge_update = true
+  when '--no-acceptance'
+    run_acceptance = false
   end
 end
 
@@ -256,7 +261,7 @@ confirm_no_changes
 run('pdk', 'validate')
 run('pdk', 'test', 'unit')
 
-if File.exist?('spec/acceptance')
+if run_acceptance && File.exist?('spec/acceptance')
   run('./test.sh', 'init', 'run', 'destroy')
 end
 


### PR DESCRIPTION
Allows releasing when acceptance tests are broken (for reasons unrelated to the module itself).

Submitting this as a PR so that acceptance tests will run in GitHub Actions, since they don’t work on my laptop. If they pass, I’ll cut a Z release to keep git and the released module more in sync.

This also adds a note to CHANGELOG.md.