### PR TITLE
Security fix, enforce file ownership, and run acceptance test on macOS

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -54,11 +54,15 @@ jobs:
     name: Acceptance tests
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-        agent:
-          - puppet7
-          - puppet8
+        include:
+          - os: ubuntu-latest
+            puppet: 6
+          - os: ubuntu-latest
+            puppet: 7
+          - os: ubuntu-latest
+            puppet: 8
+          - os: macos-latest
+            puppet: 8
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -66,18 +70,26 @@ jobs:
     - name: Install Puppet
       run: |
         set -ex
-        distro=$(lsb_release -cs)
-        deb_name="${{ matrix.agent }}-release-${distro}.deb"
-        curl -sSO  "https://apt.puppet.com/${deb_name}"
-        sudo dpkg -i "$deb_name"
-        rm "$deb_name"
-        sudo apt-get update -qq
-        sudo apt-get install -qy puppet-agent pdk
-    - name: Build module
-      run: pdk build
-    - name: Install module
-      run: sudo -E /opt/puppetlabs/bin/puppet module install pkg/*.tar.gz
+        case ${{ matrix.os }} in
+          macos*)
+            brew install --cask puppetlabs/puppet/puppet-agent-${{ matrix.puppet }}
+            brew install --cask puppetlabs/puppet/pdk
+          ;;
+          ubuntu*)
+            distro=$(lsb_release -cs)
+            deb_name="puppet${{ matrix.puppet }}-release-${distro}.deb"
+            curl -sSO  "https://apt.puppet.com/${deb_name}"
+            sudo dpkg -i "$deb_name"
+            rm "$deb_name"
+            sudo apt-get update -qq
+            sudo apt-get install -qy puppet-agent pdk
+          ;;
+          *)
+            echo ::error::Unsupported platform
+            exit 1
+          ;;
+        esac
     - name: Install PDK dependencies
-      run: sudo -E pdk bundle install
+      run: sudo -E /opt/puppetlabs/pdk/bin/pdk bundle install
     - name: Run acceptance tests
-      run: sudo -E pdk bundle exec rake litmus:acceptance:localhost
+      run: sudo -E /opt/puppetlabs/pdk/bin/pdk bundle exec rake litmus:acceptance:localhost

--- a/.sync.yml
+++ b/.sync.yml
@@ -6,6 +6,9 @@
 # See https://github.com/danielparks/pdk-templates/blob/main/config_defaults.yml
 # for the default values.
 ---
+.github/workflows/pr-checks.yaml:
+  additional-platforms:
+    - macos-latest
 spec/default_facts.yml:
   extra_facts:
     identity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+### Security fix
+
+Certain Go tarballs (see below) had files owned by non-root users:
+
+    ❯ curl -SsL https://go.dev/dl/go1.20.14.darwin-amd64.tar.gz | tar -tzvf - | head -3
+    drwxr-xr-x  0 0      0           0 Feb  2 10:19 go/
+    -rw-r--r--  0 gopher wheel    1339 Feb  2 10:09 go/CONTRIBUTING.md
+    -rw-r--r--  0 gopher wheel    1479 Feb  2 10:09 go/LICENSE
+
+In this case, the non-root user in question mapped to the first user created on
+the macOS system (UID 501).
+
+When running as root, previous versions of dp-golang would preserve file
+ownership when extracting the tarball, even if `owner` was set to something
+else. **This meant that files, such as the `go` binary, ended up being writable
+by a non-root user.**
+
+This version of dp-golang enables [`tar`]’s `--no-same-owner` and
+`--no-same-permissions` flags, which cause files to be extracted as the user
+running Puppet, or as the user/group specified in the Puppet code.
+
+GitHub security advisory: [GHSA-8h8m-h98f-vv84]
+
+#### Affected Go tarballs
+
+  * Go for macOS version 1.4.3 through 1.21rc3, inclusive.
+  * go1.4-bootstrap-20170518.tar.gz
+  * go1.4-bootstrap-20170531.tar.gz
+
+[`tar`]: https://www.man7.org/linux/man-pages/man1/tar.1.html
+[GHSA-8h8m-h98f-vv84]: https://github.com/danielparks/puppet-golang/security/advisories/GHSA-8h8m-h98f-vv84
+
 ## Release 1.2.6
 
 * Synced with [PDK][].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ GitHub security advisory: [GHSA-8h8m-h98f-vv84]
 [`tar`]: https://www.man7.org/linux/man-pages/man1/tar.1.html
 [GHSA-8h8m-h98f-vv84]: https://github.com/danielparks/puppet-golang/security/advisories/GHSA-8h8m-h98f-vv84
 
+### Changes
+
+As part of the security fix mentioned above, it became necessary to be more
+agressive about ensuring that the owner and group of files in the installation
+are correct. dp-golang now deletes and recreates any Go installation it finds
+that has a file or directory with the wrong owner or group.
+
 ## Release 1.2.6
 
 * Synced with [PDK][].

--- a/manifests/from_tarball.pp
+++ b/manifests/from_tarball.pp
@@ -109,7 +109,7 @@ define golang::from_tarball (
       ensure        => present,
       extract       => true,
       extract_path  => $go_dir,
-      extract_flags => '--strip-components 1 -xf',
+      extract_flags => '--strip-components 1 --no-same-owner --no-same-permissions -xf',
       user          => $owner,
       group         => $group,
       source        => $source,

--- a/manifests/from_tarball.pp
+++ b/manifests/from_tarball.pp
@@ -46,6 +46,9 @@ define golang::from_tarball (
   String[1]                          $mode       = '0755',
   Stdlib::Unixpath                   $state_file = golang::state_file($go_dir),
 ) {
+  $encoded_go_dir = $go_dir.regsubst('/', '_', 'G')
+  $archive_path = "/tmp/puppet-golang${encoded_go_dir}.tar.gz"
+
   if $ensure != any_version {
     # Used to ensure that the installation is updated when $source changes.
     $file_ensure = $ensure ? {
@@ -70,6 +73,38 @@ define golang::from_tarball (
     }
   }
 
+  if $ensure == present or $ensure == any_version {
+    # Remove Go installation if any of its files have the wrong user or group.
+    # This will cause it to be replaced with a fresh installation.
+    exec { "dp/golang check ownership of ${go_dir}":
+      command     => ['rm', '-rf', $go_dir],
+      environment => [
+        "GO_DIR=${go_dir}",
+        "OWNER=${owner}",
+        "GROUP=${group}",
+      ],
+      path        => ['/usr/local/bin', '/usr/bin', '/bin'],
+      onlyif      => 'find "$GO_DIR" "(" "(" -not -user "$OWNER" ")" -or "(" -not -group "$GROUP" ")" ")" -print -quit | grep .',
+      before      => File[$go_dir],
+      notify      => Archive[$archive_path],
+    }
+  }
+
+  # File[$state_file] changing should only trigger an update when ensure is
+  # present, and not any_version.
+  if $ensure == present {
+    # If the $go_dir/bin directory exists, archive won't update it. Also, we
+    # want to remove any files that are not present in the new version.
+    exec { "dp/golang refresh go installation at ${go_dir}":
+      command     => ['rm', '-rf', $go_dir],
+      path        => ['/usr/local/bin', '/usr/bin', '/bin'],
+      refreshonly => true,
+      subscribe   => File[$state_file],
+      before      => File[$go_dir],
+      notify      => Archive[$archive_path],
+    }
+  }
+
   $directory_ensure = $ensure ? {
     'present'     => directory,
     'any_version' => directory,
@@ -85,24 +120,6 @@ define golang::from_tarball (
   }
 
   if $ensure == present or $ensure == any_version {
-    $encoded_go_dir = $go_dir.regsubst('/', '_', 'G')
-    $archive_path = "/tmp/puppet-golang${encoded_go_dir}.tar.gz"
-
-    # Only trigger an update when ensure is present, and not any_version.
-    if $ensure == present {
-      # If the $go_dir/bin directory exists, archive won't update it. Also, we
-      # want to remove any files that are not present in the new version.
-      exec { "dp/golang refresh go installation at ${go_dir}":
-        command     => ['rm', '-rf', $go_dir],
-        path        => ['/usr/local/bin', '/usr/bin', '/bin'],
-        user        => $facts['identity']['user'],
-        refreshonly => true,
-        subscribe   => File[$state_file],
-        before      => File[$go_dir],
-        notify      => Archive[$archive_path],
-      }
-    }
-
     include archive
 
     archive { $archive_path:

--- a/metadata.json
+++ b/metadata.json
@@ -85,5 +85,5 @@
   ],
   "pdk-version": "3.0.1",
   "template-url": "https://github.com/danielparks/pdk-templates#main",
-  "template-ref": "heads/main-0-g2f62871"
+  "template-ref": "heads/main-0-gde8efe4"
 }

--- a/spec/acceptance/golang_from_tarball_spec.rb
+++ b/spec/acceptance/golang_from_tarball_spec.rb
@@ -2,15 +2,39 @@
 
 require 'spec_helper_acceptance'
 
+# This tarball contains entries owned by gopher (501) rather than root.
+source_url = 'https://go.dev/dl/go1.10.4.darwin-amd64.tar.gz'
+
+newer_source_url = 'https://go.dev/dl/go1.19.1.darwin-amd64.tar.gz'
+
 describe 'defined type golang::from_tarball' do
   context 'repeated root installs:' do
     context 'default ensure with 1.10.4 source' do
       it 'installs Go' do
-        idempotent_apply(<<~'PUPPET')
+        idempotent_apply(<<~"PUPPET")
           golang::from_tarball { '/opt/go':
-            source => 'https://go.dev/dl/go1.10.4.linux-amd64.tar.gz',
+            source => '#{source_url}',
           }
         PUPPET
+      end
+
+      describe file('/opt/go') do
+        it { is_expected.to be_directory }
+        its(:mode) { is_expected.to eq '755' }
+        its(:owner) { is_expected.to eq 'root' }
+      end
+
+      describe file('/opt/.go.source_url') do
+        it { is_expected.to be_file }
+        its(:mode) { is_expected.to eq '444' }
+        its(:owner) { is_expected.to eq 'root' }
+        its(:content) { is_expected.to include "\n#{source_url}\n" }
+      end
+
+      describe file('/opt/go/bin/go') do
+        it { is_expected.to be_file }
+        its(:mode) { is_expected.to eq '755' }
+        its(:owner) { is_expected.to eq 'root' }
       end
 
       describe file('/opt/go/VERSION') do
@@ -20,12 +44,19 @@ describe 'defined type golang::from_tarball' do
 
     context 'ensure => present' do
       it 'causes no changes' do
-        apply_manifest(<<~'PUPPET', catch_changes: true)
+        apply_manifest(<<~"PUPPET", catch_changes: true)
           golang::from_tarball { '/opt/go':
             ensure => present,
-            source => 'https://go.dev/dl/go1.10.4.linux-amd64.tar.gz',
+            source => '#{source_url}',
           }
         PUPPET
+      end
+
+      describe file('/opt/.go.source_url') do
+        it { is_expected.to be_file }
+        its(:mode) { is_expected.to eq '444' }
+        its(:owner) { is_expected.to eq 'root' }
+        its(:content) { is_expected.to include "\n#{source_url}\n" }
       end
 
       describe file('/opt/go/VERSION') do
@@ -33,14 +64,21 @@ describe 'defined type golang::from_tarball' do
       end
     end
 
-    context 'ensure => any_version with 1.19.1 source' do
+    context 'ensure => any_version with newer source' do
       it 'causes no changes' do
-        apply_manifest(<<~'PUPPET', catch_changes: true)
+        apply_manifest(<<~"PUPPET", catch_changes: true)
           golang::from_tarball { '/opt/go':
             ensure => any_version,
-            source => 'https://go.dev/dl/go1.19.1.linux-amd64.tar.gz',
+            source => '#{newer_source_url}',
           }
         PUPPET
+      end
+
+      describe file('/opt/.go.source_url') do
+        it { is_expected.to be_file }
+        its(:mode) { is_expected.to eq '444' }
+        its(:owner) { is_expected.to eq 'root' }
+        its(:content) { is_expected.to include "\n#{source_url}\n" }
       end
 
       describe file('/opt/go/VERSION') do
@@ -48,14 +86,21 @@ describe 'defined type golang::from_tarball' do
       end
     end
 
-    context 'ensure => present with 1.19.1 source' do
+    context 'ensure => present with newer source' do
       it 'causes changes' do
-        apply_manifest(<<~'PUPPET', expect_changes: true)
+        apply_manifest(<<~"PUPPET", expect_changes: true)
           golang::from_tarball { '/opt/go':
             ensure => present,
-            source => 'https://go.dev/dl/go1.19.1.linux-amd64.tar.gz',
+            source => '#{newer_source_url}',
           }
         PUPPET
+      end
+
+      describe file('/opt/.go.source_url') do
+        it { is_expected.to be_file }
+        its(:mode) { is_expected.to eq '444' }
+        its(:owner) { is_expected.to eq 'root' }
+        its(:content) { is_expected.to include "\n#{newer_source_url}\n" }
       end
 
       describe file('/opt/go/VERSION') do
@@ -65,12 +110,20 @@ describe 'defined type golang::from_tarball' do
 
     context 'ensure => absent' do
       it do
-        idempotent_apply(<<~'PUPPET')
+        idempotent_apply(<<~"PUPPET")
           golang::from_tarball { '/opt/go':
             ensure => absent,
-            source => 'https://go.dev/dl/go1.19.1.linux-amd64.tar.gz',
+            source => '#{newer_source_url}',
           }
         PUPPET
+      end
+
+      describe file('/opt/go') do
+        it { is_expected.not_to exist }
+      end
+
+      describe file('/opt/.go.source_url') do
+        it { is_expected.not_to exist }
       end
 
       describe file('/opt/go/VERSION') do

--- a/spec/acceptance/golang_installation_spec.rb
+++ b/spec/acceptance/golang_installation_spec.rb
@@ -221,10 +221,10 @@ describe 'defined type golang::installation' do
         user { 'user':
           home       => '#{home}/user',
           gid        => 'user',
-          managehome => true,
+          managehome => false,
         }
 
-        file { '#{home}/user/bin':
+        file { ['#{home}/user', '#{home}/user/bin']:
           ensure => directory,
           owner  => 'user',
           group  => 'user',

--- a/spec/acceptance/golang_installation_spec.rb
+++ b/spec/acceptance/golang_installation_spec.rb
@@ -198,33 +198,33 @@ describe 'defined type golang::installation' do
 
   context 'multiple user installs with linked_binaries' do
     it do
-      idempotent_apply(<<~'PUPPET')
-        golang::installation { '/home/user/go1.10.4':
+      idempotent_apply(<<~"PUPPET")
+        golang::installation { '#{home}/user/go1.10.4':
           ensure => '1.10.4',
           owner  => 'user',
           group  => 'user',
           mode   => '0700',
         }
 
-        golang::installation { '/home/user/go1.19.1':
+        golang::installation { '#{home}/user/go1.19.1':
           ensure => '1.19.1',
           owner  => 'user',
           group  => 'user',
           mode   => '0700',
         }
 
-        golang::linked_binaries { '/home/user/go1.19.1':
-          into_bin => '/home/user/bin',
+        golang::linked_binaries { '#{home}/user/go1.19.1':
+          into_bin => '#{home}/user/bin',
         }
 
         group { 'user': }
         user { 'user':
-          home       => '/home/user',
+          home       => '#{home}/user',
           gid        => 'user',
           managehome => true,
         }
 
-        file { '/home/user/bin':
+        file { '#{home}/user/bin':
           ensure => directory,
           owner  => 'user',
           group  => 'user',
@@ -234,74 +234,74 @@ describe 'defined type golang::installation' do
     end
 
     ['1.10.4', '1.19.1'].each do |version|
-      describe file("/home/user/go#{version}") do
+      describe file("#{home}/user/go#{version}") do
         it { is_expected.to be_directory }
         it { is_expected.to be_owned_by 'user' }
         it { is_expected.to be_grouped_into 'user' }
         it { is_expected.to be_mode 700 } # WTF converted to octal
       end
 
-      describe file("/home/user/go#{version}/bin/go") do
+      describe file("#{home}/user/go#{version}/bin/go") do
         it { is_expected.to be_file }
         it { is_expected.to be_owned_by 'user' }
         it { is_expected.to be_grouped_into 'user' }
         it { is_expected.to be_mode 755 } # WTF converted to octal
       end
 
-      describe command("/home/user/go#{version}/bin/go version") do
+      describe command("#{home}/user/go#{version}/bin/go version") do
         its(:stdout) { is_expected.to start_with("go version go#{version} ") }
         its(:stderr) { is_expected.to eq '' }
         its(:exit_status) { is_expected.to eq 0 }
       end
     end
 
-    describe file('/home/user/bin/go') do
+    describe file("#{home}/user/bin/go") do
       it { is_expected.to be_symlink }
-      it { is_expected.to be_linked_to '/home/user/go1.19.1/bin/go' }
+      it { is_expected.to be_linked_to "#{home}/user/go1.19.1/bin/go" }
     end
   end
 
   context 'multiple user installs with mixed ensure and linked_binaries' do
     it do
-      idempotent_apply(<<~'PUPPET')
-        golang::installation { '/home/user/go1.10.4':
+      idempotent_apply(<<~"PUPPET")
+        golang::installation { '#{home}/user/go1.10.4':
           ensure => '1.10.4',
           owner  => 'user',
           group  => 'user',
         }
-        golang::installation { '/home/user/go1.19.1':
+        golang::installation { '#{home}/user/go1.19.1':
           ensure => absent,
         }
-        golang::linked_binaries { '/home/user/go1.10.4':
-          into_bin => '/home/user/bin',
+        golang::linked_binaries { '#{home}/user/go1.10.4':
+          into_bin => '#{home}/user/bin',
         }
       PUPPET
     end
 
-    describe file('/home/user/go1.10.4') do
+    describe file("#{home}/user/go1.10.4") do
       it { is_expected.to be_directory }
       it { is_expected.to be_owned_by 'user' }
       it { is_expected.to be_grouped_into 'user' }
       it { is_expected.to be_mode 755 } # WTF converted to octal
     end
 
-    describe file('/home/user/go1.10.4/bin/go') do
+    describe file("#{home}/user/go1.10.4/bin/go") do
       it { is_expected.to be_file }
       it { is_expected.to be_owned_by 'user' }
       it { is_expected.to be_grouped_into 'user' }
       it { is_expected.to be_mode 755 } # WTF converted to octal
     end
 
-    describe file('/home/user/go1.19.1') do
+    describe file("#{home}/user/go1.19.1") do
       it { is_expected.not_to exist }
     end
 
-    describe file('/home/user/bin/go') do
+    describe file("#{home}/user/bin/go") do
       it { is_expected.to be_symlink }
-      it { is_expected.to be_linked_to '/home/user/go1.10.4/bin/go' }
+      it { is_expected.to be_linked_to "#{home}/user/go1.10.4/bin/go" }
     end
 
-    describe command('/home/user/bin/go version') do
+    describe command("#{home}/user/bin/go version") do
       its(:stdout) { is_expected.to start_with('go version go1.10.4 ') }
       its(:stderr) { is_expected.to eq '' }
       its(:exit_status) { is_expected.to eq 0 }
@@ -310,33 +310,33 @@ describe 'defined type golang::installation' do
 
   context 'multiple user uninstalls with linked_binaries' do
     it do
-      idempotent_apply(<<~'PUPPET')
-        golang::installation { '/home/user/go1.10.4':
+      idempotent_apply(<<~"PUPPET")
+        golang::installation { '#{home}/user/go1.10.4':
           ensure => absent,
           owner  => 'user',
           group  => 'user',
         }
-        golang::installation { '/home/user/go1.19.1':
+        golang::installation { '#{home}/user/go1.19.1':
           ensure => absent,
           owner  => 'user',
           group  => 'user',
         }
-        golang::linked_binaries { '/home/user/go1.10.4':
+        golang::linked_binaries { '#{home}/user/go1.10.4':
           ensure   => absent,
-          into_bin => '/home/user/bin',
+          into_bin => '#{home}/user/bin',
         }
       PUPPET
     end
 
-    describe file('/home/user/go1.10.4') do
+    describe file("#{home}/user/go1.10.4") do
       it { is_expected.not_to exist }
     end
 
-    describe file('/home/user/go1.19.1') do
+    describe file("#{home}/user/go1.19.1") do
       it { is_expected.not_to exist }
     end
 
-    describe file('/home/user/bin/go') do
+    describe file("#{home}/user/bin/go") do
       it { is_expected.not_to exist }
     end
   end

--- a/spec/acceptance/golang_installation_spec.rb
+++ b/spec/acceptance/golang_installation_spec.rb
@@ -111,6 +111,13 @@ describe 'defined type golang::installation' do
         its(:owner) { is_expected.to eq 'root' }
       end
 
+      describe file("/opt/.go#{version}.source_url") do
+        it { is_expected.to be_file }
+        its(:mode) { is_expected.to eq '444' }
+        its(:owner) { is_expected.to eq 'root' }
+        its(:content) { is_expected.to include "\nhttps://go.dev/dl/" }
+      end
+
       describe file("/opt/go#{version}/bin/go") do
         it { is_expected.to be_file }
         it { is_expected.to be_executable }
@@ -239,6 +246,14 @@ describe 'defined type golang::installation' do
         its(:owner) { is_expected.to eq 'user' }
         its(:group) { is_expected.to eq 'user' }
         it { is_expected.to be_mode 700 } # WTF converted to octal
+      end
+
+      describe file("#{home}/user/.go#{version}.source_url") do
+        it { is_expected.to be_file }
+        its(:mode) { is_expected.to eq '444' }
+        its(:owner) { is_expected.to eq 'user' }
+        its(:group) { is_expected.to eq 'user' }
+        its(:content) { is_expected.to include "\nhttps://go.dev/dl/" }
       end
 
       describe file("#{home}/user/go#{version}/bin/go") do

--- a/spec/acceptance/golang_installation_spec.rb
+++ b/spec/acceptance/golang_installation_spec.rb
@@ -108,13 +108,13 @@ describe 'defined type golang::installation' do
     ['1.10.4', '1.19.1'].each do |version|
       describe file("/opt/go#{version}") do
         it { is_expected.to be_directory }
-        it { is_expected.to be_owned_by 'root' }
+        its(:owner) { is_expected.to eq 'root' }
       end
 
       describe file("/opt/go#{version}/bin/go") do
         it { is_expected.to be_file }
         it { is_expected.to be_executable }
-        it { is_expected.to be_owned_by 'root' }
+        its(:owner) { is_expected.to eq 'root' }
       end
 
       describe command("/opt/go#{version}/bin/go version") do
@@ -148,7 +148,7 @@ describe 'defined type golang::installation' do
     describe file('/opt/go1.10.4/bin/go') do
       it { is_expected.to be_file }
       it { is_expected.to be_executable }
-      it { is_expected.to be_owned_by 'root' }
+      its(:owner) { is_expected.to eq 'root' }
     end
 
     describe file('/opt/go1.19.1') do
@@ -236,15 +236,15 @@ describe 'defined type golang::installation' do
     ['1.10.4', '1.19.1'].each do |version|
       describe file("#{home}/user/go#{version}") do
         it { is_expected.to be_directory }
-        it { is_expected.to be_owned_by 'user' }
-        it { is_expected.to be_grouped_into 'user' }
+        its(:owner) { is_expected.to eq 'user' }
+        its(:group) { is_expected.to eq 'user' }
         it { is_expected.to be_mode 700 } # WTF converted to octal
       end
 
       describe file("#{home}/user/go#{version}/bin/go") do
         it { is_expected.to be_file }
-        it { is_expected.to be_owned_by 'user' }
-        it { is_expected.to be_grouped_into 'user' }
+        its(:owner) { is_expected.to eq 'user' }
+        its(:group) { is_expected.to eq 'user' }
         it { is_expected.to be_mode 755 } # WTF converted to octal
       end
 
@@ -280,15 +280,15 @@ describe 'defined type golang::installation' do
 
     describe file("#{home}/user/go1.10.4") do
       it { is_expected.to be_directory }
-      it { is_expected.to be_owned_by 'user' }
-      it { is_expected.to be_grouped_into 'user' }
+      its(:owner) { is_expected.to eq 'user' }
+      its(:group) { is_expected.to eq 'user' }
       it { is_expected.to be_mode 755 } # WTF converted to octal
     end
 
     describe file("#{home}/user/go1.10.4/bin/go") do
       it { is_expected.to be_file }
-      it { is_expected.to be_owned_by 'user' }
-      it { is_expected.to be_grouped_into 'user' }
+      its(:owner) { is_expected.to eq 'user' }
+      its(:group) { is_expected.to eq 'user' }
       it { is_expected.to be_mode 755 } # WTF converted to octal
     end
 

--- a/spec/acceptance/golang_spec.rb
+++ b/spec/acceptance/golang_spec.rb
@@ -50,6 +50,13 @@ describe 'class golang' do
       its(:owner) { is_expected.to eq 'root' }
     end
 
+    describe file('/usr/local/.go.source_url') do
+      it { is_expected.to be_file }
+      its(:mode) { is_expected.to eq '444' }
+      its(:owner) { is_expected.to eq 'root' }
+      its(:content) { is_expected.to include "\nhttps://go.dev/dl/" }
+    end
+
     describe file('/usr/local/go/bin/go') do
       it { is_expected.to be_file }
       it { is_expected.to be_executable }
@@ -83,6 +90,10 @@ describe 'class golang' do
     end
 
     describe file('/usr/local/go') do
+      it { is_expected.not_to exist }
+    end
+
+    describe file('/usr/local/.go.source_url') do
       it { is_expected.not_to exist }
     end
 

--- a/spec/acceptance/golang_spec.rb
+++ b/spec/acceptance/golang_spec.rb
@@ -8,13 +8,13 @@ describe 'class golang' do
 
     describe file('/usr/local/go') do
       it { is_expected.to be_directory }
-      it { is_expected.to be_owned_by 'root' }
+      its(:owner) { is_expected.to eq 'root' }
     end
 
     describe file('/usr/local/go/bin/go') do
       it { is_expected.to be_file }
       it { is_expected.to be_executable }
-      it { is_expected.to be_owned_by 'root' }
+      its(:owner) { is_expected.to eq 'root' }
     end
 
     describe file('/usr/local/bin/go') do
@@ -47,13 +47,13 @@ describe 'class golang' do
 
     describe file('/usr/local/go') do
       it { is_expected.to be_directory }
-      it { is_expected.to be_owned_by 'root' }
+      its(:owner) { is_expected.to eq 'root' }
     end
 
     describe file('/usr/local/go/bin/go') do
       it { is_expected.to be_file }
       it { is_expected.to be_executable }
-      it { is_expected.to be_owned_by 'root' }
+      its(:owner) { is_expected.to eq 'root' }
     end
 
     describe file('/usr/local/bin/go') do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -8,9 +8,19 @@ PuppetLitmus.configure!
 
 # For some reason litmusimage/ubuntu:22.04 doesn’t come with sudo.
 RSpec.configure do |config|
-  config.before(:suite) do
-    litmus = Class.new.extend(PuppetLitmus)
-    litmus.apply_manifest("package { 'sudo': }", catch_failures: true)
+  if RUBY_PLATFORM.include?('linux')
+    config.before(:suite) do
+      litmus = Class.new.extend(PuppetLitmus)
+      litmus.apply_manifest("package { 'sudo': }", catch_failures: true)
+    end
+  end
+end
+
+def home
+  if RUBY_PLATFORM.include?('darwin')
+    '/Users'
+  else
+    '/home'
   end
 end
 


### PR DESCRIPTION
### [Security: ignore file ownership when extracting Go](https://github.com/danielparks/puppet-golang/pull/40/commits/548e3d0ba6c89411e9f9eb543bec6567e24d5d7c) 

Certain Go tarballs specified that some files, such as the `go` binary, were supposed to be owned by a non-root user. When running as root, dp-golang extracted those files and preserved ownership, which lead to those files being writable by a non-root user.

Affected Go tarballs:

  * Go for macOS version 1.4.3 through 1.21rc3, inclusive.
  * go1.4-bootstrap-20170518.tar.gz
  * go1.4-bootstrap-20170531.tar.gz

This switches to extracting the tarballs with `tar`’s `--no-same-owner` and `--no-same-permissions` flags.

### [Enforce owner/group of Go installations](https://github.com/danielparks/puppet-golang/pull/40/commits/85c2cdc91b9118b24eec6be4a6e9240cc41bca82) 
 
This now recreates a Go installation if any of its files or directories have the wrong owner or group.

### Run acceptance tests on macOS

This updates from the template to support macOS as a runner in acceptance tests in our PR Checks, and adds support for macOS to the acceptance tests themselves. This makes other improvements to acceptance tests as well.