### PR TITLE
Acceptance tests: check that `sudo` is installed

### DIFF
--- a/spec/acceptance/golang_spec.rb
+++ b/spec/acceptance/golang_spec.rb
@@ -73,7 +73,7 @@ describe 'class golang' do
       # These tests are run in order, so this isn’t strictly necessary. However,
       # I’d prefer to avoid relying on the previous tests, so here it is. In
       # order to avoid unnecessary changes, this should match the last test run
-      apply_manifest('include golang')
+      apply_manifest('include golang', catch_failures: true)
 
       idempotent_apply(<<~'END')
         class { 'golang':


### PR DESCRIPTION
We install `sudo` before running acceptance tests. This modifies the code to check that the installation was successful before going on.