### PR TITLE
Release 1.2.9: PDK sync and typo fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## main branch
+## Release 1.2.9 (2025-10-25)
 
 * Synced with [PDK][] and disabled Puppet 6 testing, since the package signing
   key is no longer valid.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ All notable changes to this project will be documented in this file.
 
 [PDK]: https://www.puppet.com/docs/pdk/latest/pdk.html
 
-## Release 1.2.8
+## Release 1.2.8 (2024-06-03)
 
 * Synced with [PDK][].
 
 [PDK]: https://www.puppet.com/docs/pdk/latest/pdk.html
 
-## Release 1.2.7
+## Release 1.2.7 (2024-02-29)
 
 ### Security fix
 
@@ -58,7 +58,7 @@ aggressive about ensuring that the owner and group of files in the installation
 are correct. dp-golang now deletes and recreates any Go installation it finds
 that has a file or directory with the wrong owner or group.
 
-## Release 1.2.6
+## Release 1.2.6 (2024-02-15)
 
 * Synced with [PDK][].
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+## main branch
+
 ## Release 1.2.9 (2025-10-25)
 
 * Synced with [PDK][] and disabled Puppet 6 testing, since the package signing

--- a/metadata.json
+++ b/metadata.json
@@ -85,5 +85,5 @@
   ],
   "pdk-version": "3.4.0",
   "template-url": "https://github.com/danielparks/pdk-templates#main",
-  "template-ref": "heads/main-0-gf3a27f5"
+  "template-ref": "heads/main-0-g5a17a8d"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "dp-golang",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "author": "Daniel Parks",
   "summary": "Simple yet flexible Go installations. Allows automatic updates, multiple installations, and may be run as non-root.",
   "license": "Apache-2.0",


### PR DESCRIPTION
- **PDK update: updates to release.rb.**
  

- **CHANGELOG.md: add dates for last few releases.**
  

- **Release 1.2.9: PDK sync and typo fixes.**
  

- **Add “## main branch” header back to CHANGELOG.md.**
  